### PR TITLE
Update .env varaible form KAFKA_TOPIC to KAFKA_TOPIC_NAME

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,7 +2,7 @@ require('dotenv').config();
 
 const config = {
   KafkaHost:process.env.KAFKA_HOST,
-  KafkaTopic: process.env.KAFKA_TOPIC
+  KafkaTopic: process.env.KAFKA_TOPIC_NAME
 };
 
 module.exports = config;

--- a/sample.env
+++ b/sample.env
@@ -1,2 +1,2 @@
 KAFKA_HOST= 'localhost:9092'
-KAFKA_TOPIC= 'kafka-example-topic'
+KAFKA_TOPIC_NAME= 'kafka-example-topic'


### PR DESCRIPTION
This threw the team off for a bit. For some reason, we thought we needed to find a port address and we tried many variations until we realized that this is literally the topic name. 

If we had looked at the `sample.env` sooner that would have been been great help.